### PR TITLE
Allow easy customization of entities

### DIFF
--- a/Get-TeamsStatus.ps1
+++ b/Get-TeamsStatus.ps1
@@ -9,8 +9,9 @@
 .DESCRIPTION
     This script is monitoring the Teams client logfile for certain changes. It
     makes use of two sensors that are created in Home Assistant up front.
-    sensor.teams_status displays that availability status of your Teams client based 
-    on the icon overlay in the taskbar on Windows. sensor.teams_activity shows if you 
+    The status entity (sensor.teams_status by default) displays that availability 
+    status of your Teams client based on the icon overlay in the taskbar on Windows. 
+    The activity entity (sensor.teams_activity by default) shows if you
     are in a call or not based on the App updates deamon, which is paused as soon as 
     you join a call.
 .PARAMETER SetStatus
@@ -41,6 +42,10 @@ $lgInACall = "In a call"
 $iconInACall = "mdi:phone-in-talk-outline"
 $iconNotInACall = "mdi:phone-off"
 
+# Set entities to post to
+$entityStatus = "sensor.teams_status"
+$entityActivity = "sensor.teams_activity"
+
 ################################################################
 # Don't edit the code below, unless you know what you're doing #
 ################################################################
@@ -59,7 +64,7 @@ If($null -ne $SetStatus){
      }
 	 
     $params = $params | ConvertTo-Json
-    Invoke-RestMethod -Uri "$HAUrl/api/states/sensor.teams_status" -Method POST -Headers $headers -Body ([System.Text.Encoding]::UTF8.GetBytes($params)) -ContentType "application/json"
+    Invoke-RestMethod -Uri "$HAUrl/api/states/$entityStatus" -Method POST -Headers $headers -Body ([System.Text.Encoding]::UTF8.GetBytes($params)) -ContentType "application/json"
 	
     break
 }
@@ -151,7 +156,7 @@ If ($CurrentStatus -ne $Status) {
      }
 	 
     $params = $params | ConvertTo-Json
-    Invoke-RestMethod -Uri "$HAUrl/api/states/sensor.teams_status" -Method POST -Headers $headers -Body ([System.Text.Encoding]::UTF8.GetBytes($params)) -ContentType "application/json" 
+    Invoke-RestMethod -Uri "$HAUrl/api/states/$entityStatus" -Method POST -Headers $headers -Body ([System.Text.Encoding]::UTF8.GetBytes($params)) -ContentType "application/json" 
 }
 
 If ($CurrentActivity -ne $Activity) {
@@ -165,7 +170,7 @@ If ($CurrentActivity -ne $Activity) {
         }
      }
     $params = $params | ConvertTo-Json
-    Invoke-RestMethod -Uri "$HAUrl/api/states/sensor.teams_activity" -Method POST -Headers $headers -Body ([System.Text.Encoding]::UTF8.GetBytes($params)) -ContentType "application/json" 
+    Invoke-RestMethod -Uri "$HAUrl/api/states/$entityActivity" -Method POST -Headers $headers -Body ([System.Text.Encoding]::UTF8.GetBytes($params)) -ContentType "application/json" 
 }
     Start-Sleep 1
 } Until ($Enable -eq 0)


### PR DESCRIPTION
This PR makes it easy to customize the entities that are used to post the Teams Status to. This is convenient if your Home Assistant has multiple people that you want to be able to see the status for. In my personal case, the sensors are called `sensor.teams_status_robert` and `sensor.teams_activity_robert`.

When updating the script with a new version, you only need to update the top set of strings.