### PR TITLE
Added webcam status capability

### DIFF
--- a/Get-TeamsStatus.ps1
+++ b/Get-TeamsStatus.ps1
@@ -136,8 +136,17 @@ If ($null -ne $TeamsProcess) {
     ElseIf ($TeamsActivity -like "*Pausing daemon App updates*" -or `
         $TeamsActivity -like "*SfB:TeamsActiveCall*" -or `
         $TeamsActivity -like "*name: desktop_call_state_change_send, isOngoing: true*") {
-        $Activity = $lgInACall
-        $ActivityIcon = $iconInACall
+        
+		$webcam = Get-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\webcam\NonPackaged\C:#Users#$UserName#AppData#Local#Microsoft#Teams#current#Teams.exe" -Name LastUsedTimeStop | select LastUsedTimeStop
+		
+		if ($webcam.LastUsedTimeStop -eq 0){
+			$Activity = $lgInACallWebcamOn
+			$ActivityIcon = $iconInACall
+		}
+		else {
+			$Activity = $lgInACall
+			$ActivityIcon = $iconInACall
+		}
         Write-Host $Activity
     }
 }

--- a/Settings.ps1
+++ b/Settings.ps1
@@ -14,8 +14,8 @@ $lgPresenting = "Presenting"
 $lgFocusing = "Focusing"
 $lgInAMeeting = "In a meeting"
 $lgOffline = "Offline"
-$lgNotInACall = "Not in a call"
-$lgInACall = "In a call"
+$lgInACall = "In a call - camera off"
+$lgInACallWebcamOn = "In a call - camera on"
 
 # Set icons to use for call activity
 $iconInACall = "mdi:phone-in-talk-outline"


### PR DESCRIPTION
Suggested PR which adds in webcam monitor capability if Teams is in a call, will check registry key to see if Teams is using the webcam. If it is, it will reflect "In a call - camera on". Otherwise, "In a call - camera off".

Likely needs testing and possibly a check on whether registry key is present or not to prevent errors.