### PR TITLE
Jeedom compatibility -UTF8 compatibility - local - variable appdata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Settings.local.ps1

--- a/Get-TeamsStatus.ps1
+++ b/Get-TeamsStatus.ps1
@@ -69,15 +69,25 @@ If($null -ne $SetStatus){
         Invoke-RestMethod -Uri "$HAUrl/api/states/$entityStatus" -Method POST -Headers $headers -Body ([System.Text.Encoding]::UTF8.GetBytes($params)) -ContentType "application/json"
     }
     if (($null -ne $JeedomToken) -and ($null -ne $JeedomUrl)) {
-        Invoke-WebRequest -UseBasicParsing -Uri "https://$JeedomUrl/core/api/jeeApi.php?plugin=virtual&type=event&apikey=$JeedomToken&id=$JeedomStatusId&value=$SetStatus"
+        $Response = Invoke-WebRequest -Uri "https://$JeedomUrl/core/api/jeeApi.php?plugin=virtual&type=event&apikey=$JeedomToken&id=$JeedomStatusId&value=$SetStatus"
+        if ($Response|Where-Object {$_.StatusCode -ne 200}) {
+            Write-Host "Error to contact Jeedom"
+        }
     }
     break
+}
+
+If ($env:APPDATA -match "C:\\Users") {
+	$teamsLogPath = "$env:APPDATA\Microsoft\Teams\logs.txt"
+}
+Else {
+	$teamsLogPath = "C:\Users\$UserName\AppData\Roaming\Microsoft\Teams\logs.txt"
 }
 
 # Start monitoring the Teams logfile when no parameter is used to run the script
 DO {
 # Get Teams Logfile and last icon overlay status
-$TeamsStatus = Get-Content -Path $env:APPDATA"\Microsoft\Teams\logs.txt" -encoding utf8 -Tail 1000 | Select-String -Pattern `
+$TeamsStatus = Get-Content -Path $teamsLogPath -encoding utf8 -Tail 1000 | Select-String -Pattern `
   'Setting the taskbar overlay icon -',`
   'StatusIndicatorStateService: Added' | Select-Object -Last 1 
 
@@ -85,7 +95,7 @@ $TeamsStatus = Get-Content -Path $env:APPDATA"\Microsoft\Teams\logs.txt" -encodi
 # Write-Host "test variable UTF8 $(Convert-Umlaut($lgAvailable)) $(Convert-Umlaut($lgBusy)) $(Convert-Umlaut($lgOnThePhone)) $(Convert-Umlaut($lgAway)) $(Convert-Umlaut($lgBeRightBack)) $(Convert-Umlaut($lgDoNotDisturb)) $(Convert-Umlaut($lgPresenting)) $(Convert-Umlaut($lgFocusing)) $(Convert-Umlaut($lgInAMeeting)) $(Convert-Umlaut($lgOffline)) $(Convert-Umlaut($lgNotInACall)) $(Convert-Umlaut($lgInACall))"
 
 # Get Teams Logfile and last app update deamon status
-$TeamsActivity = Get-Content -Path $env:APPDATA"\Microsoft\Teams\logs.txt" -encoding utf8 -Tail 1000 | Select-String -Pattern `
+$TeamsActivity = Get-Content -Path $teamsLogPath -encoding utf8 -Tail 1000 | Select-String -Pattern `
   'Resuming daemon App updates',`
   'Pausing daemon App updates',`
   'SfB:TeamsNoCall',`

--- a/Get-TeamsStatus.ps1
+++ b/Get-TeamsStatus.ps1
@@ -27,6 +27,23 @@
 # Configuring parameter for interactive run
 Param($SetStatus)
 
+function Convert-Umlaut
+{
+  param
+  (
+    [Parameter(Mandatory)]
+    $Text
+  )
+       
+  $output = $Text.Replace('Ã©','é').Replace('Ã´','ô')
+  $isCapitalLetter = $Text -ceq $Text.toUpper()
+  if ($isCapitalLetter) 
+  { 
+    $output = $output.toUpper() 
+  }
+  $output
+}
+
 # Import Settings PowerShell script
 . ($PSScriptRoot + "\Settings.local.ps1")
 
@@ -64,6 +81,9 @@ $TeamsStatus = Get-Content -Path $env:APPDATA"\Microsoft\Teams\logs.txt" -encodi
   'Setting the taskbar overlay icon -',`
   'StatusIndicatorStateService: Added' | Select-Object -Last 1 
 
+# To debug another language
+# Write-Host "test variable UTF8 $(Convert-Umlaut($lgAvailable)) $(Convert-Umlaut($lgBusy)) $(Convert-Umlaut($lgOnThePhone)) $(Convert-Umlaut($lgAway)) $(Convert-Umlaut($lgBeRightBack)) $(Convert-Umlaut($lgDoNotDisturb)) $(Convert-Umlaut($lgPresenting)) $(Convert-Umlaut($lgFocusing)) $(Convert-Umlaut($lgInAMeeting)) $(Convert-Umlaut($lgOffline)) $(Convert-Umlaut($lgNotInACall)) $(Convert-Umlaut($lgInACall))"
+
 # Get Teams Logfile and last app update deamon status
 $TeamsActivity = Get-Content -Path $env:APPDATA"\Microsoft\Teams\logs.txt" -encoding utf8 -Tail 1000 | Select-String -Pattern `
   'Resuming daemon App updates',`
@@ -78,93 +98,93 @@ $TeamsProcess = Get-Process -Name Teams -ErrorAction SilentlyContinue
 
 # Check if Teams is running and start monitoring the log if it is
 If ($null -ne $TeamsProcess) {
-    Write-Host "status $TeamsStatus et variable exemple $lgDoNotDisturb"
-    If($TeamsStatus -eq $null){ }
-    ElseIf ($TeamsStatus -like "*Setting the taskbar overlay icon - $lgAvailable*" -or `
+    If($null -eq $TeamsStatus){ }
+    ElseIf ($TeamsStatus -like "*Setting the taskbar overlay icon - $(Convert-Umlaut($lgAvailable))*" -or `
         $TeamsStatus -like "*StatusIndicatorStateService: Added Available*" -or `
         $TeamsStatus -like "*StatusIndicatorStateService: Added NewActivity (current state: Available -> NewActivity*") {
-        $Status = $lgAvailable
+        $Status = $(Convert-Umlaut($lgAvailable))
         Write-Host $Status
     }
-    ElseIf ($TeamsStatus -like "*Setting the taskbar overlay icon - $lgBusy*" -or `
+    ElseIf ($TeamsStatus -like "*Setting the taskbar overlay icon - $(Convert-Umlaut($lgBusy))*" -or `
             $TeamsStatus -like "*StatusIndicatorStateService: Added Busy*" -or `
             $TeamsStatus -like "*Setting the taskbar overlay icon - $lgOnThePhone*" -or `
             $TeamsStatus -like "*StatusIndicatorStateService: Added OnThePhone*" -or `
             $TeamsStatus -like "*StatusIndicatorStateService: Added NewActivity (current state: Busy -> NewActivity*") {
-        $Status = $lgBusy
+        $Status = $(Convert-Umlaut($lgBusy))
         Write-Host $Status
     }
-    ElseIf ($TeamsStatus -like "*Setting the taskbar overlay icon - $lgAway*" -or `
+    ElseIf ($TeamsStatus -like "*Setting the taskbar overlay icon - $(Convert-Umlaut($lgAway))*" -or `
             $TeamsStatus -like "*StatusIndicatorStateService: Added Away*" -or `
             $TeamsStatus -like "*StatusIndicatorStateService: Added NewActivity (current state: Away -> NewActivity*") {
-        $Status = $lgAway
+        $Status = $(Convert-Umlaut($lgAway))
         Write-Host $Status
     }
-    ElseIf ($TeamsStatus -like "*Setting the taskbar overlay icon - $lgBeRightBack*" -or `
+    ElseIf ($TeamsStatus -like "*Setting the taskbar overlay icon - $(Convert-Umlaut($lgBeRightBack))*" -or `
             $TeamsStatus -like "*StatusIndicatorStateService: Added BeRightBack*" -or `
             $TeamsStatus -like "*StatusIndicatorStateService: Added NewActivity (current state: BeRightBack -> NewActivity*") {
-        $Status = $lgBeRightBack
+        $Status = $(Convert-Umlaut($lgBeRightBack))
         Write-Host $Status
     }
-    ElseIf ($TeamsStatus -like "*Setting the taskbar overlay icon - $lgDoNotDisturb *" -or `
+    ElseIf ($TeamsStatus -like "*Setting the taskbar overlay icon - $(Convert-Umlaut($lgDoNotDisturb)) *" -or `
             $TeamsStatus -like "*StatusIndicatorStateService: Added DoNotDisturb*" -or `
             $TeamsStatus -like "*StatusIndicatorStateService: Added NewActivity (current state: DoNotDisturb -> NewActivity*") {
-        $Status = $lgDoNotDisturb
+        $Status = $(Convert-Umlaut($lgDoNotDisturb))
         Write-Host $Status
     }
-    ElseIf ($TeamsStatus -like "*Setting the taskbar overlay icon - $lgFocusing*" -or `
+    ElseIf ($TeamsStatus -like "*Setting the taskbar overlay icon - $(Convert-Umlaut($lgFocusing))*" -or `
             $TeamsStatus -like "*StatusIndicatorStateService: Added Focusing*" -or `
             $TeamsStatus -like "*StatusIndicatorStateService: Added NewActivity (current state: Focusing -> NewActivity*") {
-        $Status = $lgFocusing
+        $Status = $(Convert-Umlaut($lgFocusing))
         Write-Host $Status
     }
-    ElseIf ($TeamsStatus -like "*Setting the taskbar overlay icon - $lgPresenting*" -or `
+    ElseIf ($TeamsStatus -like "*Setting the taskbar overlay icon - $(Convert-Umlaut($lgPresenting))*" -or `
             $TeamsStatus -like "*StatusIndicatorStateService: Added Presenting*" -or `
             $TeamsStatus -like "*StatusIndicatorStateService: Added NewActivity (current state: Presenting -> NewActivity*") {
-        $Status = $lgPresenting
+        $Status = $(Convert-Umlaut($lgPresenting))
         Write-Host $Status
     }
-    ElseIf ($TeamsStatus -like "*Setting the taskbar overlay icon - $lgInAMeeting*" -or `
+    ElseIf ($TeamsStatus -like "*Setting the taskbar overlay icon - $(Convert-Umlaut($lgInAMeeting))*" -or `
             $TeamsStatus -like "*StatusIndicatorStateService: Added InAMeeting*" -or `
             $TeamsStatus -like "*StatusIndicatorStateService: Added NewActivity (current state: InAMeeting -> NewActivity*") {
-        $Status = $lgInAMeeting
+        $Status = $(Convert-Umlaut($lgInAMeeting))
         Write-Host $Status
     }
-    ElseIf ($TeamsStatus -like "*Setting the taskbar overlay icon - $lgOffline*" -or `
+    ElseIf ($TeamsStatus -like "*Setting the taskbar overlay icon - $(Convert-Umlaut($lgOffline))*" -or `
             $TeamsStatus -like "*StatusIndicatorStateService: Added Offline*") {
-        $Status = $lgOffline
+        $Status = $(Convert-Umlaut($lgOffline))
         Write-Host $Status
     }
 
-    If($TeamsActivity -eq $null){ }
+    If($null -eq $TeamsActivity){ }
     ElseIf ($TeamsActivity -like "*Resuming daemon App updates*" -or `
         $TeamsActivity -like "*SfB:TeamsNoCall*" -or `
         $TeamsActivity -like "*name: desktop_call_state_change_send, isOngoing: false*") {
-        $Activity = $lgNotInACall
+        $Activity = $(Convert-Umlaut($lgNotInACall))
         $ActivityIcon = $iconNotInACall
         Write-Host $Activity
     }
     ElseIf ($TeamsActivity -like "*Pausing daemon App updates*" -or `
         $TeamsActivity -like "*SfB:TeamsActiveCall*" -or `
         $TeamsActivity -like "*name: desktop_call_state_change_send, isOngoing: true*") {
-        $Activity = $lgInACall
+        $Activity = $(Convert-Umlaut($lgInACall))
         $ActivityIcon = $iconInACall
         Write-Host $Activity
     }
 }
 # Set status to Offline when the Teams application is not running
 Else {
-        $Status = $lgOffline
-        $Activity = $lgNotInACall
+        $Status = $(Convert-Umlaut($lgOffline))
+        $Activity = $(Convert-Umlaut($lgNotInACall))
         $ActivityIcon = $iconNotInACall
         Write-Host $Status
         Write-Host $Activity
 }
 
-# Call Home Assistant API to set the status and activity sensors
-If ($CurrentStatus -ne $Status -and $Status -ne $null) {
-    $CurrentStatus = $Status
 
+If ($CurrentStatus -ne $Status -and $null -ne $Status) {
+    $CurrentStatus = $Status
+    
+    # Call Home Assistant API to set the status and activity sensors
     if (($null -ne $HAToken) -and ($null -ne $HAUrl)) {
         $params = @{
         "state"="$CurrentStatus";
@@ -177,8 +197,12 @@ If ($CurrentStatus -ne $Status -and $Status -ne $null) {
         $params = $params | ConvertTo-Json
         Invoke-RestMethod -Uri "$HAUrl/api/states/$entityStatus" -Method POST -Headers $headers -Body ([System.Text.Encoding]::UTF8.GetBytes($params)) -ContentType "application/json" 
     }
+    # Call Jeedom to set the status and activity sensors
     if (($null -ne $JeedomToken) -and ($null -ne $JeedomUrl)) {
-        Invoke-WebRequest -UseBasicParsing -Uri "https://$JeedomUrl/core/api/jeeApi.php?plugin=virtual&type=event&apikey=$JeedomToken&id=$JeedomStatusId&value=$Status"
+        $Response = Invoke-WebRequest -Uri "https://$JeedomUrl/core/api/jeeApi.php?plugin=virtual&type=event&apikey=$JeedomToken&id=$JeedomStatusId&value=$Status"
+        if ($Response|Where-Object {$_.StatusCode -ne 200}) {
+            Write-Host "Error to contact Jeedom"
+        }
     }
 }
 
@@ -197,10 +221,14 @@ If ($CurrentActivity -ne $Activity) {
         Invoke-RestMethod -Uri "$HAUrl/api/states/$entityActivity" -Method POST -Headers $headers -Body ([System.Text.Encoding]::UTF8.GetBytes($params)) -ContentType "application/json" 
     }
     if (($null -ne $JeedomToken) -and ($null -ne $JeedomUrl)) {
-        Invoke-WebRequest -UseBasicParsing -Uri "https://$JeedomUrl/core/api/jeeApi.php?plugin=virtual&type=event&apikey=$JeedomToken&id=$JeedomActivityId&value=$Activity"
+        $Response = Invoke-WebRequest -Uri "https://$JeedomUrl/core/api/jeeApi.php?plugin=virtual&type=event&apikey=$JeedomToken&id=$JeedomActivityId&value=$Activity"
+        if ($Response|Where-Object {$_.StatusCode -ne 200}) {
+            Write-Host "Error to contact Jeedom"
+        }
     }
 }
-Write-Host ("status : $TeamsStatus and activity $TeamsActivity")
-Write-Host ("currentstatus : $CurrentStatus and currentactivity $CurrentActivity")
+# Write-Host ("status : $TeamsStatus and activity $TeamsActivity")
+# Write-Host ("status $Status")
+# Write-Host ("currentstatus : $CurrentStatus and currentactivity $CurrentActivity")
     Start-Sleep 1
 } Until ($Enable -eq 0)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,12 @@ For Jeedom, you need to create a Virtual with 2 sensors and type "other" :
 Once saved, the command's ID are visible.
 
 # Important
-This solution is created to work with Home Assistant and Jeedom. It will work with any home automation platform that provides an API, but you probably need to change the PowerShell code.
+This solution is created to work with Home Assistant or Jeedom. It will work with any home automation platform that provides an API, but you probably need to change the PowerShell code.
+
+Please check your language for the settings! Powershell hasn't have a good implementation for UTF8, we need to replace value in variables. Currently English and French are good. Maybe you need to add characters at this line in the script (and share it!) :
+```Powershell
+$output = $Text.Replace('Ã©','é').Replace('Ã´','ô')
+```
 
 # Requirements
 ## Home Assistant
@@ -59,8 +64,9 @@ sensor:
   * Replace `<HAURL>` or `<Jeedom URL>` with the URL to your Home Assistant / Jeedom server
   * Adjust the language settings to your preferences
 # Installation
-Start a elevated PowerShell prompt, browse to C:\Scripts and run the following command:
+Start a elevated PowerShell prompt, browse to the TeamsStatus folder and run the following command:
 ```powershell
+New-Item -Path "c:\Scripts\" -ItemType Directory
 Copy-Item -Path .\nssm.exe -Destination "c:\Scripts\"
 Copy-Item -Path .\Settings.local.ps1 -Destination "c:\Scripts\"
 Copy-Item -Path .\Get-TeamsStatus.ps1 -Destination "c:\Scripts\"

--- a/README.md
+++ b/README.md
@@ -3,16 +3,22 @@ We're working a lot at our home office these days. Several people already found 
 
 Microsoft provides the status of your account that is used in Teams via the Graph API. To access the Graph API, your organization needs to grant consent for the organization so everybody can read their Teams status. Since my organization didn't want to grant consent, I needed to find a workaround, which I found in monitoring the Teams client logfile for certain changes.
 
-This script makes use of two sensors that are created in Home Assistant up front:
+For Home Assistant, this script makes use of two sensors that are created in Home Assistant up front:
 * sensor.teams_status
 * sensor.teams_activity
 
 sensor.teams_status displays that availability status of your Teams client based on the icon overlay in the taskbar on Windows. sensor.teams_activity shows if you are in a call or not based on the App updates deamon, which is paused as soon as you join a call.
 
+For Jeedom, you need to create a Virtual with 2 sensors and type "other" :
+* status
+* activity
+Once saved, the command's ID are visible.
+
 # Important
-This solution is created to work with Home Assistant. It will work with any home automation platform that provides an API, but you probably need to change the PowerShell code.
+This solution is created to work with Home Assistant and Jeedom. It will work with any home automation platform that provides an API, but you probably need to change the PowerShell code.
 
 # Requirements
+## Home Assistant
 * Create the three Teams sensors in the Home Assistant configuration.yaml file
 ```yaml
 input_text:
@@ -40,18 +46,28 @@ sensor:
 * Generate a Long-lived access token ([see HA documentation](https://developers.home-assistant.io/docs/auth_api/#long-lived-access-token))
 * Copy and temporarily save the token somewhere you can find it later
 * Restart Home Assistant to have the new sensors added
-* Download the files from this repository and save them to C:\Scripts
-* Edit the Settings.ps1 file and:
+
+## Jeedom
+* Add the `Virtuel` plugin if you don't have it
+* Create a virtuel `teams mode` with 2 infos command, type `other`
+* Save and copy the ID's that were genereted
+
+# Configuration
+* Copy the Settings.ps1 file to Settings.local.ps1 and:
   * Replace `<Insert token>` with the token you generated
   * Replace `<UserName>` with the username that is logged in to Teams and you want to monitor
-  * Replace `<HA URL>` with the URL to your Home Assistant server
+  * Replace `<HAURL>` or `<Jeedom URL>` with the URL to your Home Assistant / Jeedom server
   * Adjust the language settings to your preferences
-* Start a elevated PowerShell prompt, browse to C:\Scripts and run the following command:
+# Installation
+Start a elevated PowerShell prompt, browse to C:\Scripts and run the following command:
 ```powershell
+Copy-Item -Path .\nssm.exe -Destination "c:\Scripts\"
+Copy-Item -Path .\Settings.local.ps1 -Destination "c:\Scripts\"
+Copy-Item -Path .\Get-TeamsStatus.ps1 -Destination "c:\Scripts\"
 Set-ExecutionPolicy -ExecutionPolicy RemoteSigned
-Unblock-File .\Settings.ps1
-Unblock-File .\Get-TeamsStatus.ps1
-Start-Process -FilePath .\nssm.exe -ArgumentList 'install "Microsoft Teams Status Monitor" "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" "-command "& { . C:\Scripts\Get-TeamsStatus.ps1 }"" ' -NoNewWindow -Wait
+Unblock-File c:\Scripts\Settings.local.ps1
+Unblock-File c:\Scripts\Get-TeamsStatus.ps1
+Start-Process -FilePath "c:\Scripts\nssm.exe" -ArgumentList 'install "Microsoft Teams Status Monitor" "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" "-command "& { . C:\Scripts\Get-TeamsStatus.ps1 }"" ' -NoNewWindow -Wait
 Start-Service -Name "Microsoft Teams Status Monitor"
 ```
 

--- a/Settings-en.ps1
+++ b/Settings-en.ps1
@@ -1,7 +1,13 @@
 # Configure the variables below that will be used in the script
-$HAToken = "<Insert token>" # Example: eyJ0eXAiOiJKV1...
 $UserName = "<UserName>" # When not sure, open a command prompt and type: echo %USERNAME%
+
+$HAToken = "<Insert token>" # Example: eyJ0eXAiOiJKV1...
 $HAUrl = "<HAUrl>" # Example: https://yourha.duckdns.org
+
+$JeedomToken = "<Insert token>" # Example: eyJ0eXAiOiJKV1...
+$JeedomUrl = "<JeedomUrl>" # Example: https://yourjeedom.duckdns.org
+$JeedomStatusId = "<ID>" # Example : 745
+$JeedomActivityId = "<ID>" # Example : 746
 
 # Set language variables below
 $lgAvailable = "Available"

--- a/Settings-en.ps1
+++ b/Settings-en.ps1
@@ -1,5 +1,5 @@
 # Configure the variables below that will be used in the script
-$UserName = "<UserName>" # When not sure, open a command prompt and type: echo %USERNAME%
+$UserName = "<UserName>" # Need when running as a service (When not sure, open a command prompt and type: echo %USERNAME%)
 
 $HAToken = "<Insert token>" # Example: eyJ0eXAiOiJKV1...
 $HAUrl = "<HAUrl>" # Example: https://yourha.duckdns.org

--- a/Settings-fr.ps1
+++ b/Settings-fr.ps1
@@ -1,0 +1,37 @@
+# Configure the variables below that will be used in the script
+$UserName = "<UserName>" # When not sure, open a command prompt and type: echo %USERNAME%
+
+$HAToken = "<Insert token>" # Example: eyJ0eXAiOiJKV1...
+$HAUrl = "<HAUrl>" # Example: https://yourha.duckdns.org
+
+$JeedomToken = "<Insert token>" # Example: eyJ0eXAiOiJKV1...
+$JeedomUrl = "<JeedomUrl>" # Example: https://yourjeedom.duckdns.org
+$JeedomStatusId = "<ID>" # Example : 745
+$JeedomActivityId = "<ID>" # Example : 746
+
+# Set language variables below
+$lgAvailable = "Disponible"
+$lgBusy = "Occupé"
+$lgOnThePhone = "Au téléphone"
+$lgAway = "Absent(e)"
+$lgBeRightBack = "De retour bientôt"
+$lgDoNotDisturb = "Ne pas déranger"
+$lgPresenting = "En présentation"
+$lgFocusing = "Focusing"
+$lgInAMeeting = "En réunion"
+$lgOffline = "Hors connexion"
+$lgNotInACall = "Plus en appel"
+$lgInACall = "En appel"
+
+# Set icons to use for call activity
+$iconInACall = "mdi:phone-in-talk-outline"
+$iconNotInACall = "mdi:phone-off"
+$iconMonitoring = "mdi:api"
+
+# Set entities to post to
+$entityStatus = "sensor.teams_status"
+$entityStatusName = "Microsoft Teams status"
+$entityActivity = "sensor.teams_activity"
+$entityActivityName = "Microsoft Teams activity"
+$entityHeartbeat = "binary_sensor.teams_monitoring"
+$entityHeartbeatName = "Microsoft Teams monitoring"

--- a/Settings-fr.ps1
+++ b/Settings-fr.ps1
@@ -1,5 +1,5 @@
 # Configure the variables below that will be used in the script
-$UserName = "<UserName>" # When not sure, open a command prompt and type: echo %USERNAME%
+$UserName = "<UserName>" # Need when running as a service (When not sure, open a command prompt and type: echo %USERNAME%)
 
 $HAToken = "<Insert token>" # Example: eyJ0eXAiOiJKV1...
 $HAUrl = "<HAUrl>" # Example: https://yourha.duckdns.org


### PR DESCRIPTION
- Add jeedom compatibility with condition based on provisioned variables
- Add a condition on $env:APPDATA : if you run it manually use it, but in service it never go in the user folder and use a variable in Settings.local.ps1 (take from chriscolden fork)
- Add UTF8 compatibility (powershell and UTF8 is crap....) and tested in french en english
- Add local languages settings example (en/fr) and base on .gitignore use a Settings.local.ps1
- Add information to the readme and bugfix a dependence for using c:\scripts and not the project directory to set nssm.exe as a service 

Maybe need to check if the compatibility with HA is keeping 