### PR TITLE
Original installation command failed to start service. This worked for me.

### DIFF
--- a/Install.txt
+++ b/Install.txt
@@ -1,5 +1,5 @@
 Set-ExecutionPolicy -ExecutionPolicy RemoteSigned
 Unblock-File .\Settings.ps1
 Unblock-File .\Get-TeamsStatus.ps1
-Start-Process -FilePath .\nssm.exe -ArgumentList 'install "Microsoft Teams Status Monitor" "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" "-command "& { . C:\Scripts\Get-TeamsStatus.ps1 }"" ' -NoNewWindow -Wait
+Start-Process -FilePath .\nssm.exe -ArgumentList 'install "Microsoft Teams Status Monitor" "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" "-ExecutionPolicy Bypass -NoProfile -File C:\Scripts\Get-TeamsStatus.ps1"' -NoNewWindow -WaitNoNewWindow -Wait
 Start-Service -Name "Microsoft Teams Status Monitor"


### PR DESCRIPTION
I am not sure why or if this is a valid pull request. Just figured I do this instead of opening an issue.

For some reason the service failed to start when using the original command: Start-Process -FilePath .\nssm.exe -ArgumentList 'install "Microsoft Teams Status Monitor" "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" "-command "& { . C:\Scripts\Get-TeamsStatus.ps1 }"" ' -NoNewWindow -Wait

It worked for me when I used the command:
Start-Process -FilePath .\nssm.exe -ArgumentList 'install "Microsoft Teams Status Monitor" "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" "-ExecutionPolicy Bypass -NoProfile -File C:\Scripts\Get-TeamsStatus.ps1"' -NoNewWindow -Wait